### PR TITLE
Bugfixes + New Feature

### DIFF
--- a/src/com/ssplugins/ssperm/Manager.java
+++ b/src/com/ssplugins/ssperm/Manager.java
@@ -1,6 +1,7 @@
 package com.ssplugins.ssperm;
 
 import com.ssplugins.ssperm.cmd.MainCommand;
+import com.ssplugins.ssperm.cmd.MainTabCompleter;
 import com.ssplugins.ssperm.events.SSPReloadEvent;
 import com.ssplugins.ssperm.perm.GroupManager;
 import com.ssplugins.ssperm.perm.PlayerManager;
@@ -30,6 +31,7 @@ class Manager implements SSPermAPI {
 		groupMan.loadGroups();
 		Bukkit.getOnlinePlayers().forEach(attMan::setup);
 		plugin.getCommand("ssperm").setExecutor(new MainCommand());
+		plugin.getCommand("ssperm").setTabCompleter(new MainTabCompleter());
 		plugin.getServer().getPluginManager().registerEvents(new Events(this), plugin);
 	}
 	

--- a/src/com/ssplugins/ssperm/Manager.java
+++ b/src/com/ssplugins/ssperm/Manager.java
@@ -82,6 +82,7 @@ class Manager implements SSPermAPI {
 	public boolean setChatFormat(String format) {
 		if (format == null || (!format.contains("<player>") || !format.contains("<msg>"))) return false;
 		getOptions().set("chatFormat", format);
+		playerMan.reloadFormats();
 		return true;
 	}
 	

--- a/src/com/ssplugins/ssperm/PlayerMan.java
+++ b/src/com/ssplugins/ssperm/PlayerMan.java
@@ -25,6 +25,10 @@ class PlayerMan implements PlayerManager {
 		players.clear();
 	}
 	
+	void reloadFormats() {
+		players.forEach(PermPlayer::refreshChatFormat);
+	}
+	
 	String getChatFormat(Player player) {
 		String base = Manager.getOptions().getConfig().getString("chatFormat");
 		base = Util.checkFormat(Util.color(base));

--- a/src/com/ssplugins/ssperm/cmd/MainCommand.java
+++ b/src/com/ssplugins/ssperm/cmd/MainCommand.java
@@ -39,7 +39,7 @@ public class MainCommand implements CommandExecutor {
 		if (sender.hasPermission(Perms.GROUPS) || manage) list.add("&b/ssp list &a- &7List all groups.");
 		if (sender.hasPermission(Perms.GROUPS) || manage) list.add("&b/ssp group <name> <action> <value> &a- &7Manage a group.");
 		if (sender.hasPermission(Perms.PLAYERS) || manage) list.add("&b/ssp player <name> <action> <value> &a- &7Manage a player.");
-		if (sender.hasPermission(Perms.RELOAD) || manage) list.add("&b/ssp reload &a- &7Reload the plugin. All permissions will be updated.");
+		if (sender.hasPermission(Perms.RELOAD)) list.add("&b/ssp reload &a- &7Reload the plugin. All permissions will be updated.");
 		if (sender.hasPermission(Perms.ADMIN) || all) {
 			list.add("&b/ssp create <name> &a- &7Create a group.");
 			list.add("&b/ssp remove <name> &a- &7Remove a group.");

--- a/src/com/ssplugins/ssperm/cmd/MainCommand.java
+++ b/src/com/ssplugins/ssperm/cmd/MainCommand.java
@@ -73,6 +73,9 @@ public class MainCommand implements CommandExecutor {
 			else if (args[0].equalsIgnoreCase("list") || args[0].equalsIgnoreCase("l")) {
 				groups(sender);
 			}
+			else if (args[0].equalsIgnoreCase("format") || args[0].equalsIgnoreCase("f")) {
+				format(sender, args);
+			}
 			else if (args[0].equalsIgnoreCase("reload")) {
 				reload(sender);
 			}
@@ -496,7 +499,7 @@ public class MainCommand implements CommandExecutor {
 	}
 	
 	private void reload(CommandSender sender) {
-		if (!Util.hasAny(sender, Perms.RELOAD, Perms.MANAGE, Perms.ALL)) {
+		if (!Util.hasAny(sender, Perms.RELOAD, Perms.ALL)) {
 			noPerm(sender);
 			return;
 		}

--- a/src/com/ssplugins/ssperm/cmd/MainTabCompleter.java
+++ b/src/com/ssplugins/ssperm/cmd/MainTabCompleter.java
@@ -1,0 +1,117 @@
+package com.ssplugins.ssperm.cmd;
+
+import com.ssplugins.ssperm.Perms;
+import com.ssplugins.ssperm.SSPerm;
+import com.ssplugins.ssperm.perm.Group;
+import com.ssplugins.ssperm.perm.SSPlayer;
+import com.ssplugins.ssperm.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class MainTabCompleter implements TabCompleter {
+	@Override
+	public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+		List<String> matches = new ArrayList<>();
+		if (args.length == 0) return matches;
+		StringUtil.copyPartialMatches(args[args.length - 1], getList(args.length, args, sender), matches);
+		return matches;
+	}
+	
+	private List<String> getList(int index, String[] args, CommandSender sender) {
+		if (index == 1) return getSubcommands(sender);
+		else if (index == 2) {
+			switch (args[0].toLowerCase()) {
+				case "remove":
+				case "r":
+					if (!Util.hasAny(sender, Perms.ADMIN, Perms.ALL)) break;
+				case "group":
+				case "g":
+					if (!Util.hasAny(sender, Perms.GROUPS, Perms.MANAGE, Perms.ALL)) break;
+					return SSPerm.getAPI().getGroupManager().getGroups().stream().map(Group::getName).collect(Collectors.toList());
+				case "player":
+				case "p":
+					if (!Util.hasAny(sender, Perms.PLAYERS, Perms.MANAGE, Perms.ALL)) break;
+					return Bukkit.getOnlinePlayers().stream().map(HumanEntity::getName).collect(Collectors.toList());
+			}
+		}
+		else if (index == 3) {
+			switch (args[0].toLowerCase()) {
+				case "group":
+				case "g":
+					if (!Util.hasAny(sender, Perms.GROUPS, Perms.MANAGE, Perms.ALL)) break;
+					return Arrays.asList("add", "remove", "inherit", "uninherit", "prefix", "suffix", "namecolor", "nameformat", "chatcolor", "chatformat");
+				case "player":
+				case "p":
+					if (!Util.hasAny(sender, Perms.PLAYERS, Perms.MANAGE, Perms.ALL)) break;
+					return Arrays.asList("add", "remove", "move", "prefix", "suffix", "namecolor", "nameformat", "chatcolor", "chatformat");
+			}
+		}
+		else if (index == 4) {
+			if (!Util.hasAny(sender, Perms.PLAYERS, Perms.GROUPS, Perms.MANAGE, Perms.ALL)) return new ArrayList<>();
+			switch (args[2].toLowerCase()) {
+				case "namecolor":
+				case "nc":
+				case "chatcolor":
+				case "cc":
+					return Arrays.asList("a", "b", "c", "d", "e", "f", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+				case "nameformat":
+				case "nf":
+				case "chatformat":
+				case "cf":
+					return Arrays.asList("k", "l", "m", "n", "o", "r");
+				case "remove":
+				case "r":
+					return getPermissions(args[1], args[0].equalsIgnoreCase("group") || args[0].equalsIgnoreCase("g"));
+				case "inherit":
+				case "i":
+				case "uninherit":
+				case "u":
+				case "move":
+				case "m":
+					return SSPerm.getAPI().getGroupManager().getGroups().stream().map(Group::getName).collect(Collectors.toList());
+			}
+		}
+		return new ArrayList<>();
+	}
+	
+	private List<String> getPermissions(String name, boolean group) {
+		if (group) {
+			Optional<Group> op = SSPerm.getAPI().getGroupManager().getGroup(name);
+			if (op.isPresent()) return new ArrayList<>(op.get().getPermissions().getAll());
+		}
+		else {
+			Optional<SSPlayer> op = SSPerm.getAPI().getPlayerManager().getPlayerByName(name);
+			if (op.isPresent()) return new ArrayList<>(op.get().getPermissions().getAll());
+		}
+		return new ArrayList<>();
+	}
+	
+	private List<String> getSubcommands(CommandSender sender) {
+		List<String> list = new ArrayList<>();
+		boolean manage = sender.hasPermission(Perms.MANAGE);
+		boolean all = sender.hasPermission(Perms.ALL);
+		if (all) manage = true;
+		list.add("help");
+		if (sender.hasPermission(Perms.GROUPS) || manage) list.add("list");
+		if (sender.hasPermission(Perms.GROUPS) || manage) list.add("group");
+		if (sender.hasPermission(Perms.PLAYERS) || manage) list.add("player");
+		if (sender.hasPermission(Perms.RELOAD)) list.add("reload");
+		if (sender.hasPermission(Perms.ADMIN) || all) {
+			list.add("create");
+			list.add("remove");
+			list.add("format");
+		}
+		return list;
+	}
+}


### PR DESCRIPTION
Full Tab Completion:
There is now tab completion for the /ssp command.
- Useful for quick commands or if you can't remember what there is.
- It works with groups so you can quickly find the group you want.
- It also works with permissions, to quickly remove one from a player or group.
- When setting a color or format to a group you can tab to see which colors you can use there.
- Tabbing will only show you subcommands that you have permission for.

Bug Fixes:
- The /ssp format subcommand wasn't hooked up and didn't do anything.
- The permission ssperm.manage no longer gives you ssperm.manage.reload
- Reload subcommand would show up in help message when you didn't have permission for it.